### PR TITLE
feat: CD - exe ビルド & Google Drive 自動配置

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,12 +51,7 @@ jobs:
           echo "TAG_NAME=${TAG_NAME}" >> "$GITHUB_ENV"
 
       - name: Install rclone
-        shell: bash
-        run: |
-          curl -O https://downloads.rclone.org/current/rclone-current-windows-amd64.zip
-          7z x rclone-current-windows-amd64.zip
-          mv rclone-*-windows-amd64/rclone.exe .
-          echo "$(pwd)" >> "$GITHUB_PATH"
+        run: choco install rclone -y --no-progress
 
       - name: Configure rclone
         shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "v*"
-    branches:
-      - "feature/cd-github-actions-gdrive"  # TODO: テスト後に削除
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - "feature/cd-github-actions-gdrive"  # TODO: テスト後に削除
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,13 +56,11 @@ jobs:
       - name: Configure rclone
         shell: bash
         env:
-          SA_CREDENTIALS: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          RCLONE_DRIVE_TOKEN: ${{ secrets.RCLONE_DRIVE_TOKEN }}
         run: |
           RCLONE_CONFIG_DIR="${APPDATA}/rclone"
           mkdir -p "$RCLONE_CONFIG_DIR"
-          printenv SA_CREDENTIALS > sa_credentials.json
-          SA_PATH="$(cygpath -m "$(pwd)/sa_credentials.json")"
-          printf '[gdrive]\ntype = drive\nscope = drive\nservice_account_file = %s\n' "$SA_PATH" > "$RCLONE_CONFIG_DIR/rclone.conf"
+          printf '[gdrive]\ntype = drive\nscope = drive\ntoken = %s\n' "$RCLONE_DRIVE_TOKEN" > "$RCLONE_CONFIG_DIR/rclone.conf"
 
       - name: Upload to Google Drive
         shell: bash
@@ -84,6 +82,4 @@ jobs:
       - name: Cleanup credentials
         if: always()
         shell: bash
-        run: |
-          rm -f sa_credentials.json
-          rm -f "${APPDATA}/rclone/rclone.conf"
+        run: rm -f "${APPDATA}/rclone/rclone.conf"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Build exe
         run: python setup.py build
+        env:
+          PYTHONIOENCODING: utf-8
 
       - name: Package build artifacts
         shell: bash

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Configure rclone
         shell: bash
         env:
-          SA_CREDENTIALS: ${{ secrets.RCLONE_GDRIVE_SA_CREDENTIALS }}
+          SA_CREDENTIALS: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
         run: |
           RCLONE_CONFIG_DIR="${APPDATA}/rclone"
           mkdir -p "$RCLONE_CONFIG_DIR"
@@ -67,7 +67,7 @@ jobs:
       - name: Upload to Google Drive
         shell: bash
         env:
-          GDRIVE_FOLDER_ID: ${{ secrets.GDRIVE_FOLDER_ID }}
+          GDRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
         run: |
           rclone copyto "${ZIP_NAME}" "gdrive:/${ZIP_NAME}" \
             --drive-root-folder-id="${GDRIVE_FOLDER_ID}" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,90 @@
+name: CD - Build & Deploy to Google Drive
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install cx_Freeze
+
+      - name: Build exe
+        run: python setup.py build
+
+      - name: Package build artifacts
+        shell: bash
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          if [[ "$TAG_NAME" == "$GITHUB_REF" ]]; then
+            TAG_NAME="dev-$(echo ${GITHUB_SHA} | cut -c1-7)"
+          fi
+          BUILD_DIR=$(ls -d build/exe.* | head -1)
+          ZIP_NAME="renamePdf_${TAG_NAME}.zip"
+          cd "$BUILD_DIR"
+          7z a -tzip "../../${ZIP_NAME}" ./*
+          cd ../..
+          echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
+          echo "TAG_NAME=${TAG_NAME}" >> "$GITHUB_ENV"
+
+      - name: Install rclone
+        shell: bash
+        run: |
+          curl -O https://downloads.rclone.org/current/rclone-current-windows-amd64.zip
+          7z x rclone-current-windows-amd64.zip
+          mv rclone-*-windows-amd64/rclone.exe .
+          echo "$(pwd)" >> "$GITHUB_PATH"
+
+      - name: Configure rclone
+        shell: bash
+        env:
+          SA_CREDENTIALS: ${{ secrets.RCLONE_GDRIVE_SA_CREDENTIALS }}
+        run: |
+          RCLONE_CONFIG_DIR="${APPDATA}/rclone"
+          mkdir -p "$RCLONE_CONFIG_DIR"
+          printenv SA_CREDENTIALS > sa_credentials.json
+          SA_PATH="$(cygpath -m "$(pwd)/sa_credentials.json")"
+          printf '[gdrive]\ntype = drive\nscope = drive\nservice_account_file = %s\n' "$SA_PATH" > "$RCLONE_CONFIG_DIR/rclone.conf"
+
+      - name: Upload to Google Drive
+        shell: bash
+        env:
+          GDRIVE_FOLDER_ID: ${{ secrets.GDRIVE_FOLDER_ID }}
+        run: |
+          rclone copyto "${ZIP_NAME}" "gdrive:/${ZIP_NAME}" \
+            --drive-root-folder-id="${GDRIVE_FOLDER_ID}" \
+            -v
+          echo "Uploaded ${ZIP_NAME} to Google Drive"
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.ZIP_NAME }}
+          generate_release_notes: true
+
+      - name: Cleanup credentials
+        if: always()
+        shell: bash
+        run: |
+          rm -f sa_credentials.json
+          rm -f "${APPDATA}/rclone/rclone.conf"

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ Thumbs.db
 var/
 *.pdf
 !tests/fixtures/*.pdf
+.envrc
+.ai

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ executables = [
 build_exe_options = {
     "includes": includes,  # 必要なパッケージをここに追加
     "excludes": excludes,  # 除外するパッケージをここに追加
-    "include_files": [(icon, "icons/icon.ico"), "resource.res"],
+    "include_files": [(icon, "icons/icon.ico"), "resource.res", "休日.csv"],
 }
 
 setup(


### PR DESCRIPTION
## Summary
- GitHub Actions で Windows exe ビルド → Google Drive 自動アップロードの CD パイプラインを構築
- `v*` タグ push で本番実行、`workflow_dispatch` で手動テスト実行が可能
- setup.py に `休日.csv` の同梱を追加

## 変更内容
- `.github/workflows/cd.yml` 新規作成
- `setup.py` の `include_files` に `休日.csv` 追加
- `.gitignore` に `.envrc`, `.ai` 追加

## テスト手順
1. Actions タブ → "CD - Build & Deploy to Google Drive" → "Run workflow" で手動実行
2. ビルドが成功し、Google Drive にzipがアップロードされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)