### PR TITLE
fix: CD パイプライン修正 + OAuthトークン方式への切替

### DIFF
--- a/scripts/refresh-gdrive-token.sh
+++ b/scripts/refresh-gdrive-token.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================
+# Google Drive OAuth トークン更新スクリプト
+# rclone authorize でトークンを取得し、
+# GitHub Secrets (RCLONE_DRIVE_TOKEN) を更新する
+# ============================================
+
+REPO="keishimizu26629/rename_pdf"
+SECRET_NAME="RCLONE_DRIVE_TOKEN"
+GH_CONFIG_DIR="${HOME}/.config/gh-sub"
+
+echo "=== Google Drive OAuth トークン更新 ==="
+echo ""
+
+# 前提チェック
+for cmd in rclone gh; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "エラー: ${cmd} がインストールされていません"
+    echo "  brew install ${cmd}"
+    exit 1
+  fi
+done
+
+# gh認証チェック
+if ! GH_CONFIG_DIR="$GH_CONFIG_DIR" gh auth status &>/dev/null; then
+  echo "エラー: gh CLI が認証されていません"
+  echo "  GH_CONFIG_DIR=$GH_CONFIG_DIR gh auth login"
+  exit 1
+fi
+
+echo "ブラウザが開きます。Googleアカウントでログインしてください。"
+echo ""
+
+# rclone authorize でトークン取得
+TOKEN=$(rclone authorize "drive" 2>&1 | grep -o '{.*}' | tail -1)
+
+if [ -z "$TOKEN" ]; then
+  echo "エラー: トークンの取得に失敗しました"
+  exit 1
+fi
+
+echo ""
+echo "トークン取得成功。GitHub Secrets を更新します..."
+
+# GitHub Secrets に登録
+GH_CONFIG_DIR="$GH_CONFIG_DIR" gh secret set "$SECRET_NAME" \
+  --repo "$REPO" \
+  --body "$TOKEN"
+
+echo ""
+echo "=== 完了 ==="
+echo "  リポジトリ: ${REPO}"
+echo "  Secret:     ${SECRET_NAME}"
+echo "  更新日時:   $(date '+%Y-%m-%d %H:%M:%S')"


### PR DESCRIPTION
## Summary
- サービスアカウント方式からOAuthトークン方式に変更（個人Google Driveのクォータ制限対応）
- cx_Freeze ビルド時の日本語ファイル名エンコードエラー修正
- rclone インストール方式を choco に変更
- Secret名を実際の登録名に修正
- テスト用ブランチトリガーの追加と削除
- トークン更新用スクリプト `scripts/refresh-gdrive-token.sh` を追加

## 変更ファイル
- `.github/workflows/cd.yml` - 各種修正
- `scripts/refresh-gdrive-token.sh` - 新規追加

## Test plan
- [x] GitHub Actions で全ステップ成功を確認済み（Run #22431439529）
- [x] Google Drive にzipファイルがアップロードされたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)